### PR TITLE
summaryindex

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -49,6 +49,7 @@ That process is to be determined and RChain is seeking counsel on the matter. Re
 - An [RChain YouTube channel](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w) contains updates, live webcasting, and recordings of meetings.  
 - The Cooperative has a [Facebook](https://www.facebook.com/rchaincooperative/) and [LinkedIn](https://www.linkedin.com/company/24997313/) account with an RChain Group. Please join!  
 - The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.  
+- To review past Hangout Summaries and Newsletter archives use the [Summary Index](https://github.com/rchain/Members/wiki/Weekly-Debrief-Index)
 
 
 ## Tokens


### PR DESCRIPTION
this change was to add the index of the hangout summary links https://github.com/rchain/Members/wiki/Weekly-Debrief-Index to the FAQ as a reference.