### PR TITLE
Update with Member Meeting changes #60

### DIFF
--- a/faq.md
+++ b/faq.md
@@ -45,9 +45,10 @@ There are three steering committees where Members collaborate to shape and organ
 
 **What comm channels does the Co-op use?**
 - Co-op members, leadership, and developers share a private Discord server. To become a member and access Discord, please register at [https://member.rchain.coop](https://member.rchain.coop).
+- Non-members are welcome to join a [public Discord server](https://discord.gg/fvY8qhx) which serves as a lobby and is currently bridged with the old Slack #community channel.
 - RChain Co-op's [Slack Team](https://ourchain.slack.com) is being phased out because Slack has changed its policy regarding new invitations. This policy change affects not just RChain, but all large Slack teams that support open enrollment.
 - [Github](https://github.com/rchain/) is used for code and project coordination.
-- The [RChain Twitter account](https://twitter.com/rchain_coop/) sends news and announcements.
+- The [RChain Twitter account](https://twitter.com/rchain_coop/) provides news and announcements.
 - [RChain on Medium](https://medium.com/rchain-cooperative) carries longer blog posts.
 - An [RChain YouTube channel](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w) contains updates, live webcasting, and recordings of meetings.
 - There are [RChain](https://www.reddit.com/r/rchain/) and [RChain_Official](https://www.reddit.com/r/RChain_Official/) subs on Reddit.
@@ -69,10 +70,10 @@ Here's the [financial summary, distribution, and other information](https://docs
 At the first Member Meeting in October 2017 the Members voted that "The Cooperative should sell from its treasury to put no more than 200 million RHOC tokens in circulation (tokens held by anyone, other than; 1) held by the Cooperative, or 2) burned) during the next calendar year." The full voting results are [reported on Medium](https://medium.com/rchain-cooperative/annual-meeting-summary-3827a82a2e33).
 
 **How do I see my RHOCs  in myetherwallet.com?**  \
-Click Add Custom Token, then fill in:  \
+Click “Add Custom Token”, then fill in:  \
 Contract Address: 0x168296bb09e24a88805cb9c33356536b980d3fc5  \
 Token Symbol: RHOC  \
-Decimals:  8
+Decimals: 8
 
 **Where can I trade RHOCs?**  \
 Currently on EtherDelta, OasisDex, and SingularX (these require an Ethereum client such as Metamask, Parity, or Mist):  \
@@ -94,7 +95,7 @@ Not directly; the redemption period ended in April 2017. AMPs and RHOCs are trad
 Join one of the public discussion forums (see the comm channels above). People who want to play a more active role can collaborate on coding projects, create Co-op infrastructure, and work out its governance. To participate they need to become a Co-op Member.
 
 **What is the Membership Program?**  \
-Interested individuals can become a Member of the Co-op. Benefits include: access to the private Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends, which will depend on having a working RChain blockchain. Membership requires KYC and a one-time $20 membership fee. If you'd like to join please visit [https://member.rchain.coop](https://member.rchain.coop).
+Interested individuals can become a Member of the Co-op. Benefits include: access to the private Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends. Membership requires KYC and a one-time $20 membership fee. If you'd like to join please visit [https://member.rchain.coop](https://member.rchain.coop).
 
 **I live outside of the United States. Can I join as a Member?**  \
 Yes, unless you reside in a region sanctioned by the US. The registration process will check that.
@@ -109,16 +110,16 @@ Yes. The first step is to [register as a Member](https://member.rchain.coop), th
 ## Developers
 
 **What is Pi Calculus?**  \
-“In theoretical computer science, the π-calculus is a process calculus. The π-calculus allows channel names to be communicated along the channels themselves, and in this way it is able to describe concurrent computations whose network configuration may change during the computation.” (From [https://en.wikipedia.org/wiki/Pi-calculus](https://en.wikipedia.org/wiki/Pi-calculus)). To better understand how it is being applied in the RChain development, you can reference the paper [Mobile process calculi for programming the blockchain](http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/).
+“In theoretical computer science, the π-calculus is a process calculus. The π-calculus allows channel names to be communicated along the channels themselves, and in this way it is able to describe concurrent computations whose network configuration may change during the computation.” (Ref.: [https://en.wikipedia.org/wiki/Pi-calculus](https://en.wikipedia.org/wiki/Pi-calculus)). To better understand how it is being applied in the RChain development, check out the paper [Mobile process calculi for programming the blockchain](http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/).
 
 **What skills do I need to participate?**  \
 At this point the entire development focus is on the core platform. If you’re a seasoned developer willing to learn a new programming language (Rholang), have experience with functional programming, appreciate formal specifications, or have expertise in comms then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please [join as a Member](https://member.rchain.coop) and put yourself in the Talent Pool.
 
 **How can I learn Rholang?**  \
-An understanding of Pi Calculus will help. Join the Slack #Rholang channel and ask questions.
+An understanding of Pi Calculus will help. Join the Discord #rholang channel and ask questions.
 
 **What will the license be for RChain's components?**  \
 RChain's components are all under open source and free software licenses. Our license of choice is Apache v2. Rholang is the only component currently licensed under the MIT license.
 
-### *Suggestions*
+### *Suggestions?*
 Have a question that hasn't been answered? You can suggest additional FAQ entries by including the hashtag #faq in any of the comm channels.

--- a/faq.md
+++ b/faq.md
@@ -1,14 +1,11 @@
 # RChain Cooperative FAQ
 
-    Note: the FAQ will get an update to reflect decisions made in the Cooperative Members Meeting
-    held on October 24th.
-
 ### Sections
 
 [General](#general)  
 [Cooperative](#cooperative)  
 [Tokens](#tokens)  
-[Activists](#activists)  
+[Members](#members)  
 [Developers](#developers)  
 
 ## General
@@ -36,26 +33,29 @@ The [Co-op](https://www.rchain.coop) is the organization that develops the open-
 The RChain Cooperative and RChain Holdings are both Internet companies and have participants around the world. They are Washington USA companies and the founders live in Seattle.
 
 **What is the governance model?**  
-The Co-op currently has a five-person [Board of Directors](https://www.rchain.coop/coop-information-1#board-of-directors). The officers are Greg Meredith, President, and Evan Jensen, Secretary. The Co-op is a member-driven organization, and the membership drive will begin once the regulation-related filings are completed for all U.S. states [and other jurisdictions?]. Additional board members and officers may be added. A membership meeting is planned for October 2017 in which elections will be held. Join the [RChain Slack](http://slack.rchain.coop) to learn specifics as plans take shape.
+The Co-op is a member-driven organization with an elected nine-person [Board of Directors](https://rchain.coop/coop-information-1#board-of-directors). Board seats have 3, 2, or 1 year terms. The board is composed of:
 
-**What is the Membership Program?**  
-A program is being developed, but some aspects depend on having a working RChain blockchain. Permission from each of the 50 US states is needed in order to charge a membership fee and this process should be complete in the 4th quarter of 2017.
+- 3 years: Greg Meredith, Vlad Zamfir, Ian Bloom
+- 2 years: Kenny Rowe, Evan Jensen, Alexandr Bulkin
+- 1 year: Navneet Suman, Hendrik Jan Hilbolling, David Currin
 
-**I live outside of the United States. Can I join as a Member?**  
-Yes, unless you reside in a region sanctioned by the US. Please visit [https://member.rchain.coop](https://member.rchain.coop) (requires KYC and a one-time $20 membership fee).
+The Co-op officers are Greg Meredith, President, and Evan Jensen, Secretary. XXX is this accurate?
+
+There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but are limited to 11 working members plus a chair.
 
 **What comm channels does the Co-op use?**
-- Co-op members, leadership and developers share a private **Discord server**. To become a member and access Discord, please register at [https://member.rchain.coop](https://member.rchain.coop).
+- Co-op members, leadership and developers share a private Discord server. To become a member and access Discord, please register at [https://member.rchain.coop](https://member.rchain.coop).
 - RChain Co-op's [Slack Team](https://ourchain.slack.com) is being phased out because Slack has changed its policy regarding new invitations. This policy change affects not just RChain, but all large Slack teams that support open enrollment.
-- [Github](https://github.com/rchain/) for code and project coordination.  
+- [Github](https://github.com/rchain/) is used for code and project coordination.  
 - The [RChain Twitter account](https://twitter.com/rchain_coop/) sends news and announcements.  
 - [RChain on Medium](https://medium.com/rchain-cooperative) carries longer blog posts.  
 - An [RChain YouTube channel](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w) contains updates, live webcasting, and recordings of meetings.  
 - There are [RChain](https://www.reddit.com/r/rchain/) and [RChain_Official](https://www.reddit.com/r/RChain_Official/) subs on Reddit.
-- The [rchain forum](https://bitcointalk.org/index.php?topic=1747033.0) on Bitcointalk needs attention.
+- The [RChain forum](https://bitcointalk.org/index.php?topic=1747033.0) on Bitcointalk needs attention.
 - The Cooperative has a [Facebook](https://www.facebook.com/rchaincooperative/) and [LinkedIn](https://www.linkedin.com/company/24997313/) account with an RChain Group. Please join!  
 - The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.  
-- To review past Hangout Summaries and Newsletter archives use the [Summary Index](https://github.com/rchain/Members/wiki/Weekly-Debrief-Index).
+- RChain sends out a bi-weekly newsletter. [Subscribe on the website](https://www.rchain.coop/#joinus) at the base of the main page.
+- To review past Debrief Summaries and Newsletter archives use the [Summary Index](https://github.com/rchain/Members/wiki/Weekly-Debrief-Index).
 
 
 ## Tokens
@@ -70,31 +70,40 @@ Token Symbol: RHOC
 Decimals:  8
 
 **What is the plan for supply of RHOCs, REVs, and potential other staking tokens?**  
-Here's the [financial summary, distribution, and other information](https://docs.google.com/document/d/1lCVeO63E-WVosOnBIA2hH416Hs-Z0e1Av9eJWq-L20o/edit?usp=sharing).
+Here's the [financial summary, distribution, and other information](https://docs.google.com/document/d/1lCVeO63E-WVosOnBIA2hH416Hs-Z0e1Av9eJWq-L20o/edit?usp=sharing). 
+
+At the first Member Meeting in October 2017 the Members voted that "The Cooperative should sell from its treasury to put no more than 200 million RHOC tokens in circulation (tokens held by anyone, other than; 1) held by the Cooperative, or 2) burned) during the next calendar year." The full voting results are [reported on Medium](https://medium.com/rchain-cooperative/annual-meeting-summary-3827a82a2e33).
 
 **Where can I trade RHOCs?**  
-Currently on EtherDelta and OasisDex (these require an Ethereum client such as Metamask, Parity, or Mist):  
+Currently on EtherDelta, OasisDex, and SingularX (these require an Ethereum client such as Metamask, Parity, or Mist):  
 [https://etherdelta.github.io/#RHOC-ETH](https://etherdelta.github.io/#RHOC-ETH)  
 [https://oasisdex.com/](https://oasisdex.com/)  
+[https://ex.singularx.com/exchange/RHOC/ETH](https://ex.singularx.com/exchange/RHOC/ETH)  
 For a How-To see [How to deal on exchanges like OasisDex or EtherDelta](https://github.com/rchain/Members/issues/45).
 
 **When will RHOCs be on the major crypto exchanges?**  
-The community is working on this but it’s still early days for RHOCs. Interested individuals can make requests to the exchanges and coordinate with the Co-op for documentation needed.
+The community is working on this but it’s still early days for RHOCs. Interested individuals can make requests to the exchanges and coordinate with participating Members for documentation needed.
 
 **Is it possible to redeem AMPs for RHOCs?**  
 Not directly; the redemption period ended in April 2017. AMPs and RHOCs are tradable on exchanges.
 
 
-## Activists
+## Members
 
 **How can I get involved with RChain?**  
-Community members who contribute time and energy are called Activists. These people collaborate on various projects to create Co-op infrastructure and work out its governance. To sign up there’s a [pre-registration form](https://docs.google.com/forms/d/e/1FAIpQLSecwGUVFNx_Xa_Qsw5bxLnaKstPS8kQnfrUGqpuf22rLDteDg/viewform?fbzx=-4415397049662474000) which requests basic info. After filling it out, you’ll be contacted with a welcome email containing links and information.
+Join one of the public forums open for discussion (see the Comm Channels above). People who want play a more active role can collaborate on projects to create Co-op infrastructure and work out its governance. To participate they need to become a Co-op Member.
+
+**What is the Membership Program?**  
+Interested individuals can become a Member of the Co-op. Benefits include: access to the private Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends, which will depend on having a working RChain blockchain. Membership requires KYC and a one-time $20 membership fee. If you'd like to join please visit [https://member.rchain.coop](https://member.rchain.coop).
+
+**I live outside of the United States. Can I join as a Member?**  
+Yes, unless you reside in a region sanctioned by the US. The registration process will check that.
 
 **Is there a bounty program?**  
-Yes, but the logistics of the program are still in process, partially due to legal aspects. In the meantime, Github is used for [issue tracking and project management](https://github.com/rchain/Members/).
+Yes. Bounties are task based with peer review. Tasks vary, but typically bounties are available for core development, community formation, marketing, business development, and channel operation. Github is used for [issue tracking and project management](https://github.com/rchain/Members/).
 
 **Can I earn RHOCs by participating in projects?**  
-Yes. The first step is to [register as an Activist](https://docs.google.com/forms/d/e/1FAIpQLSecwGUVFNx_Xa_Qsw5bxLnaKstPS8kQnfrUGqpuf22rLDteDg/viewform?fbzx=-4415397049662474000) and then find projects you’d like to participate in.
+Yes. The first step is to [register as a Member](https://member.rchain.coop), then find projects you’d like to participate in.
 
 
 ## Developers

--- a/faq.md
+++ b/faq.md
@@ -2,120 +2,123 @@
 
 ### Sections
 
-[General](#general)  
-[Cooperative](#cooperative)  
-[Tokens](#tokens)  
-[Members](#members)  
-[Developers](#developers)  
+[General](#general)  \
+[Cooperative](#cooperative)  \
+[Tokens](#tokens)  \
+[Members](#members)  \
+[Developers](#developers)
 
 ## General
 
-**What is RChain?**  
+**What is RChain?**  \
 RChain is a fundamentally new blockchain platform rooted in a formal model of concurrent and decentralized computation. The RChain Cooperative is leveraging that model through correct-by-construction software development to produce a concurrent, compositional, and infinitely scalable blockchain.
 
-**Where is the whitepaper?**  
+**Where is the whitepaper?**  \
 [On Github (PDF)](http://docs.google.com/gview?url=https://github.com/rchain/reference/raw/master/docs/RChainWhitepaper.pdf).
 See also the [RChain Architecture](http://rchain-architecture.readthedocs.io).
 
-**Where is the roadmap?**  
-A snapshot of the platform [milestone definitions](https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing) is available for commentary. The team has not yet committed to specific schedule dates. One estimate is the first release, Mercury, will be available after the goal of $10M committed investment is achieved.
+**Where is the roadmap?**  \
+A snapshot of the platform [milestone definitions](https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing) is available for commentary. The team has not yet committed to specific schedule dates.
 
-**How did RChain come to be?**  
+**How did RChain come to be?**  \
 RChain was the culmination of a number of innovations by founder Greg Meredith. The core of RChain is based on mobile process calculi, a branch of mathematics with approximately 30 years of history. Together with the experience of other blockchains and other technology, the RChain architecture was documented in July of 2016, while Greg was with Synereo. Synereo's goal was to create a blockchain-based social network and RChain was developed as the underlying technology. The Synereo founders decided to split in order to allow the Synereo team to focus on delivering a social network with existing blockchain technology, and for Greg to focus on realizing the vision of RChain. The RChain organizations (the [Co-op](https://www.rchain.coop/) and [Holdings company](https://www.rchain.io)) were formed in December 2016 – January 2017.
 
 
 ## Cooperative
 
-**What is the difference between the Cooperative and the Holdings company?**  
+**What is the difference between the Cooperative and the Holdings company?**  \
 The [Co-op](https://www.rchain.coop) is the organization that develops the open-source RChain platform software. It’s an open and community-driven initiative with multiple communication channels through which all are welcome to participate. [RChain Holdings](http://rchain.io/) is a for-profit entity whose mission is to grow the ecosystem around the RChain platform, through incubating startups, forming joint ventures, developing products, and delivering professional services.
 
-**Where is RChain based?**  
+**Where is RChain based?**  \
 The RChain Cooperative and RChain Holdings are both Internet companies and have participants around the world. They are Washington USA companies and the founders live in Seattle.
 
-**What is the governance model?**  
-The Co-op is a member-driven organization with an elected nine-person [Board of Directors](https://rchain.coop/coop-information-1#board-of-directors). Board seats have 3, 2, or 1 year terms. The board is composed of:
+**What is the governance model?**  \
+The Co-op is a member-driven organization with an elected nine-person [Board of Directors](https://www.rchain.coop/#team). Board seats have 3, 2, or 1 year terms. The board is composed of:
 
 - 3 years: Greg Meredith, Vlad Zamfir, Ian Bloom
 - 2 years: Kenny Rowe, Evan Jensen, Alexandr Bulkin
 - 1 year: Navneet Suman, Hendrik Jan Hilbolling, David Currin
 
-The Co-op officers are Greg Meredith, President, and Evan Jensen, Secretary. XXX is this accurate?
+The Co-op officers are: Greg Meredith, President; Evan Jensen, Secretary; Lise Rice, Treasurer.
 
 There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but are limited to 11 working members plus a chair.
 
 **What comm channels does the Co-op use?**
 - Co-op members, leadership and developers share a private Discord server. To become a member and access Discord, please register at [https://member.rchain.coop](https://member.rchain.coop).
 - RChain Co-op's [Slack Team](https://ourchain.slack.com) is being phased out because Slack has changed its policy regarding new invitations. This policy change affects not just RChain, but all large Slack teams that support open enrollment.
-- [Github](https://github.com/rchain/) is used for code and project coordination.  
-- The [RChain Twitter account](https://twitter.com/rchain_coop/) sends news and announcements.  
-- [RChain on Medium](https://medium.com/rchain-cooperative) carries longer blog posts.  
-- An [RChain YouTube channel](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w) contains updates, live webcasting, and recordings of meetings.  
+- [Github](https://github.com/rchain/) is used for code and project coordination.
+- The [RChain Twitter account](https://twitter.com/rchain_coop/) sends news and announcements.
+- [RChain on Medium](https://medium.com/rchain-cooperative) carries longer blog posts.
+- An [RChain YouTube channel](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w) contains updates, live webcasting, and recordings of meetings.
 - There are [RChain](https://www.reddit.com/r/rchain/) and [RChain_Official](https://www.reddit.com/r/RChain_Official/) subs on Reddit.
 - The [RChain forum](https://bitcointalk.org/index.php?topic=1747033.0) on Bitcointalk needs attention.
-- The Cooperative has a [Facebook](https://www.facebook.com/rchaincooperative/) and [LinkedIn](https://www.linkedin.com/company/24997313/) account with an RChain Group. Please join!  
-- The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.  
+- The Cooperative has a [Facebook](https://www.facebook.com/rchaincooperative/) and [LinkedIn](https://www.linkedin.com/company/24997313/) account with an RChain Group. Please join!
+- The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.
 - RChain sends out a bi-weekly newsletter. [Subscribe on the website](https://www.rchain.coop/#joinus) at the base of the main page.
 - To review past Debrief Summaries and Newsletter archives use the [Summary Index](https://github.com/rchain/Members/wiki/Weekly-Debrief-Index).
 
 
 ## Tokens
 
-**What are RHOCs?**  
+**What are RHOCs?**  \
 RHOCs are an Ethereum ERC20 token issued by the Co-op in early 2017 intended as a vehicle for people to get access to the technology. There are 861,185,194 RHOCs in existence. No more will be minted. RHOCs will be 1:1 redeemable for REVs, a future RChain platform native staking token.
 
-**How do I see my RHOCs  in myetherwallet.com?**  
-Click Add Custom Token, then fill in:  
-Contract Address: 0x168296bb09e24a88805cb9c33356536b980d3fc5  
-Token Symbol: RHOC  
-Decimals:  8
-
-**What is the plan for supply of RHOCs, REVs, and potential other staking tokens?**  
-Here's the [financial summary, distribution, and other information](https://docs.google.com/document/d/1lCVeO63E-WVosOnBIA2hH416Hs-Z0e1Av9eJWq-L20o/edit?usp=sharing). 
+**What is the plan for supply of RHOCs, REVs, and potential other staking tokens?**  \
+Here's the [financial summary, distribution, and other information](https://docs.google.com/document/d/1lCVeO63E-WVosOnBIA2hH416Hs-Z0e1Av9eJWq-L20o/edit?usp=sharing).
 
 At the first Member Meeting in October 2017 the Members voted that "The Cooperative should sell from its treasury to put no more than 200 million RHOC tokens in circulation (tokens held by anyone, other than; 1) held by the Cooperative, or 2) burned) during the next calendar year." The full voting results are [reported on Medium](https://medium.com/rchain-cooperative/annual-meeting-summary-3827a82a2e33).
 
-**Where can I trade RHOCs?**  
-Currently on EtherDelta, OasisDex, and SingularX (these require an Ethereum client such as Metamask, Parity, or Mist):  
-[https://etherdelta.github.io/#RHOC-ETH](https://etherdelta.github.io/#RHOC-ETH)  
-[https://oasisdex.com/](https://oasisdex.com/)  
-[https://ex.singularx.com/exchange/RHOC/ETH](https://ex.singularx.com/exchange/RHOC/ETH)  
+**How do I see my RHOCs  in myetherwallet.com?**  \
+Click Add Custom Token, then fill in:  \
+Contract Address: 0x168296bb09e24a88805cb9c33356536b980d3fc5  \
+Token Symbol: RHOC  \
+Decimals:  8
+
+**Where can I trade RHOCs?**  \
+Currently on EtherDelta, OasisDex, and SingularX (these require an Ethereum client such as Metamask, Parity, or Mist):  \
+[https://etherdelta.github.io/#RHOC-ETH](https://etherdelta.github.io/#RHOC-ETH)  \
+[https://oasisdex.com/](https://oasisdex.com/)  \
+[https://ex.singularx.com/exchange/RHOC/ETH](https://ex.singularx.com/exchange/RHOC/ETH)  \
 For a How-To see [How to deal on exchanges like OasisDex or EtherDelta](https://github.com/rchain/Members/issues/45).
 
-**When will RHOCs be on the major crypto exchanges?**  
+**When will RHOCs be on the major crypto exchanges?**  \
 The community is working on this but it’s still early days for RHOCs. Interested individuals can make requests to the exchanges and coordinate with participating Members for documentation needed.
 
-**Is it possible to redeem AMPs for RHOCs?**  
+**Is it possible to redeem AMPs for RHOCs?**  \
 Not directly; the redemption period ended in April 2017. AMPs and RHOCs are tradable on exchanges.
 
 
 ## Members
 
-**How can I get involved with RChain?**  
+**How can I get involved with RChain?**  \
 Join one of the public forums open for discussion (see the Comm Channels above). People who want play a more active role can collaborate on projects to create Co-op infrastructure and work out its governance. To participate they need to become a Co-op Member.
 
-**What is the Membership Program?**  
+**What is the Membership Program?**  \
 Interested individuals can become a Member of the Co-op. Benefits include: access to the private Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends, which will depend on having a working RChain blockchain. Membership requires KYC and a one-time $20 membership fee. If you'd like to join please visit [https://member.rchain.coop](https://member.rchain.coop).
 
-**I live outside of the United States. Can I join as a Member?**  
+**I live outside of the United States. Can I join as a Member?**  \
 Yes, unless you reside in a region sanctioned by the US. The registration process will check that.
 
-**Is there a bounty program?**  
+**Is there a bounty program?**  \
 Yes. Bounties are task based with peer review. Tasks vary, but typically bounties are available for core development, community formation, marketing, business development, and channel operation. Github is used for [issue tracking and project management](https://github.com/rchain/Members/).
 
-**Can I earn RHOCs by participating in projects?**  
+**Can I earn RHOCs by participating in projects?**  \
 Yes. The first step is to [register as a Member](https://member.rchain.coop), then find projects you’d like to participate in.
 
 
 ## Developers
 
-**What is Pi Calculus?**  
+**What is Pi Calculus?**  \
 “In theoretical computer science, the π-calculus is a process calculus. The π-calculus allows channel names to be communicated along the channels themselves, and in this way it is able to describe concurrent computations whose network configuration may change during the computation.” (From [https://en.wikipedia.org/wiki/Pi-calculus](https://en.wikipedia.org/wiki/Pi-calculus)). To better understand how it is being applied in the RChain development, you can reference the paper [Mobile process calculi for programming the blockchain](http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/).
 
-**What skills do I need to participate?**  
-At this point the entire development focus is on the core platform. If you’re a seasoned developer willing to learn a new programming language (Rholang), have experience with functional programming, appreciate formal specifications, or have expertise in comms then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please [join as an Activist](https://docs.google.com/forms/d/e/1FAIpQLSecwGUVFNx_Xa_Qsw5bxLnaKstPS8kQnfrUGqpuf22rLDteDg/viewform?fbzx=-4415397049662474000) and put yourself in the Talent Pool.
+**What skills do I need to participate?**  \
+At this point the entire development focus is on the core platform. If you’re a seasoned developer willing to learn a new programming language (Rholang), have experience with functional programming, appreciate formal specifications, or have expertise in comms then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please [join as a Member](https://member.rchain.coop) and put yourself in the Talent Pool.
 
-**How can I learn Rholang?**  
+**How can I learn Rholang?**  \
 An understanding of Pi Calculus will help. Join the Slack #Rholang channel and ask questions.
 
-**What will the license be for RChain's components?**  
+**What will the license be for RChain's components?**  \
 RChain's components are all under open source and free software licenses. Our license of choice is Apache v2. Rholang is the only component currently licensed under the MIT license.
+
+### *Suggestions*
+Have a question that hasn't been answered? You can suggest additional FAQ entries by including the hashtag #faq in any of the comm channels.

--- a/faq.md
+++ b/faq.md
@@ -21,7 +21,7 @@ See also the [RChain Architecture](http://rchain-architecture.readthedocs.io).
 A snapshot of the platform [milestone definitions](https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing) is available for commentary. The team has not yet committed to specific schedule dates.
 
 **How did RChain come to be?**  \
-RChain was the culmination of a number of innovations by founder Greg Meredith. The core of RChain is based on mobile process calculi, a branch of mathematics with approximately 30 years of history. Together with the experience of other blockchains and other technology, the RChain architecture was documented in July of 2016, while Greg was with Synereo. Synereo's goal was to create a blockchain-based social network and RChain was developed as the underlying technology. The Synereo founders decided to split in order to allow the Synereo team to focus on delivering a social network with existing blockchain technology, and for Greg to focus on realizing the vision of RChain. The RChain organizations (the [Co-op](https://www.rchain.coop/) and [Holdings company](https://www.rchain.io)) were formed in December 2016 – January 2017.
+RChain was the culmination of a number of innovations by founder Greg Meredith. The core of RChain is based on mobile process calculi, a branch of mathematics with approximately 30 years of history. Together with the experience of other blockchains and other technology, the RChain architecture was documented in July of 2016, while Greg was with Synereo. Synereo's goal was to create a blockchain-based social network and RChain was developed as the underlying technology. The Synereo founders decided to split in order to allow the Synereo team to focus on delivering a social network with existing blockchain technology, and for Greg to focus on realizing the vision of RChain. The RChain organizations (the [Co-op](https://www.rchain.coop/) and [Holdings company](https://www.rchain.io)) were formed in December 2016 - January 2017.
 
 
 ## Cooperative
@@ -30,7 +30,7 @@ RChain was the culmination of a number of innovations by founder Greg Meredith. 
 The [Co-op](https://www.rchain.coop) is the organization that develops the open-source RChain platform software. It’s an open and community-driven initiative with multiple communication channels through which all are welcome to participate. [RChain Holdings](http://rchain.io/) is a for-profit entity whose mission is to grow the ecosystem around the RChain platform, through incubating startups, forming joint ventures, developing products, and delivering professional services.
 
 **Where is RChain based?**  \
-The RChain Cooperative and RChain Holdings are both Internet companies and have participants around the world. They are Washington USA companies and the founders live in Seattle.
+The RChain Cooperative and RChain Holdings are both Internet companies and have participants around the world. They are Washington State USA companies and the founders live in Seattle.
 
 **What is the governance model?**  \
 The Co-op is a member-driven organization with an elected nine-person [Board of Directors](https://www.rchain.coop/#team). Board seats have 3, 2, or 1 year terms. The board is composed of:
@@ -41,10 +41,10 @@ The Co-op is a member-driven organization with an elected nine-person [Board of 
 
 The Co-op officers are: Greg Meredith, President; Evan Jensen, Secretary; Lise Rice, Treasurer.
 
-There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but are limited to 11 working members plus a chair.
+There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but some are limited to 11 working members plus a chair.
 
 **What comm channels does the Co-op use?**
-- Co-op members, leadership and developers share a private Discord server. To become a member and access Discord, please register at [https://member.rchain.coop](https://member.rchain.coop).
+- Co-op members, leadership, and developers share a private Discord server. To become a member and access Discord, please register at [https://member.rchain.coop](https://member.rchain.coop).
 - RChain Co-op's [Slack Team](https://ourchain.slack.com) is being phased out because Slack has changed its policy regarding new invitations. This policy change affects not just RChain, but all large Slack teams that support open enrollment.
 - [Github](https://github.com/rchain/) is used for code and project coordination.
 - The [RChain Twitter account](https://twitter.com/rchain_coop/) sends news and announcements.
@@ -53,8 +53,8 @@ There are three steering committees where Members collaborate to shape and organ
 - There are [RChain](https://www.reddit.com/r/rchain/) and [RChain_Official](https://www.reddit.com/r/RChain_Official/) subs on Reddit.
 - The [RChain forum](https://bitcointalk.org/index.php?topic=1747033.0) on Bitcointalk needs attention.
 - The Cooperative has a [Facebook](https://www.facebook.com/rchaincooperative/) and [LinkedIn](https://www.linkedin.com/company/24997313/) account with an RChain Group. Please join!
-- The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.
 - RChain sends out a bi-weekly newsletter. [Subscribe on the website](https://www.rchain.coop/#joinus) at the base of the main page.
+- The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.
 - To review past Debrief Summaries and Newsletter archives use the [Summary Index](https://github.com/rchain/Members/wiki/Weekly-Debrief-Index).
 
 
@@ -91,7 +91,7 @@ Not directly; the redemption period ended in April 2017. AMPs and RHOCs are trad
 ## Members
 
 **How can I get involved with RChain?**  \
-Join one of the public forums open for discussion (see the Comm Channels above). People who want play a more active role can collaborate on projects to create Co-op infrastructure and work out its governance. To participate they need to become a Co-op Member.
+Join one of the public discussion forums (see the comm channels above). People who want to play a more active role can collaborate on coding projects, create Co-op infrastructure, and work out its governance. To participate they need to become a Co-op Member.
 
 **What is the Membership Program?**  \
 Interested individuals can become a Member of the Co-op. Benefits include: access to the private Discord server where the RChain developers and community collaborate, electing the board members, participating in governance committees, being eligible to propose and collaborate on projects, and deciding about project approval and budget allocation. Additional benefits will be defined over time such as patronage dividends, which will depend on having a working RChain blockchain. Membership requires KYC and a one-time $20 membership fee. If you'd like to join please visit [https://member.rchain.coop](https://member.rchain.coop).

--- a/faq.md
+++ b/faq.md
@@ -53,7 +53,7 @@ There are three steering committees where Members collaborate to shape and organ
 - [RChain on Medium](https://medium.com/rchain-cooperative) carries longer blog posts.
 - An [RChain YouTube channel](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w) contains updates, live webcasting, and recordings of meetings.
 - There are [RChain](https://www.reddit.com/r/rchain/) and [RChain_Official](https://www.reddit.com/r/RChain_Official/) subs on Reddit.
-- The [RChain forum](https://bitcointalk.org/index.php?topic=1747033.0) on Bitcointalk needs attention.
+- On Bitcointalk there is a [[ANN] Official RChain Cooperative](https://bitcointalk.org/index.php?topic=2494040) thread.
 - The Cooperative has a [Facebook](https://www.facebook.com/rchaincooperative/) and [LinkedIn](https://www.linkedin.com/company/24997313/) account with an RChain Group. Please join!
 - RChain sends out a bi-weekly newsletter. [Subscribe on the website](https://www.rchain.coop/#joinus) at the base of the main page.
 - The [zoom.us](https://zoom.us/) app is used for teleconferencing such as the wednesday Weekly Debrief.

--- a/faq.md
+++ b/faq.md
@@ -18,7 +18,8 @@ RChain is a fundamentally new blockchain platform rooted in a formal model of co
 See also the [RChain Architecture](http://rchain-architecture.readthedocs.io).
 
 **Where is the roadmap?**  \
-A snapshot of the platform [milestone definitions](https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing) is available for commentary. The team has not yet committed to specific schedule dates.
+A new roadmap is being worked on, resulting from the Developer Retreat in November. There's a graphic at the top of https://rchain.atlassian.net/wiki/spaces/CORE/overview that gives a 50,000-foot view. A somewhat out-of-date snapshot of the platform is available in the [milestone definitions](https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing). 
+<!-- Needs coordination with Medha for up-to-date info links -->
 
 **How did RChain come to be?**  \
 RChain was the culmination of a number of innovations by founder Greg Meredith. The core of RChain is based on mobile process calculi, a branch of mathematics with approximately 30 years of history. Together with the experience of other blockchains and other technology, the RChain architecture was documented in July of 2016, while Greg was with Synereo. Synereo's goal was to create a blockchain-based social network and RChain was developed as the underlying technology. The Synereo founders decided to split in order to allow the Synereo team to focus on delivering a social network with existing blockchain technology, and for Greg to focus on realizing the vision of RChain. The RChain organizations (the [Co-op](https://www.rchain.coop/) and [Holdings company](https://www.rchain.io)) were formed in December 2016 - January 2017.
@@ -39,7 +40,7 @@ The Co-op is a member-driven organization with an elected nine-person [Board of 
 - 2 years: Kenny Rowe, Evan Jensen, Alexandr Bulkin
 - 1 year: Navneet Suman, Hendrik Jan Hilbolling, David Currin
 
-The Co-op officers are: Greg Meredith, President; Evan Jensen, Secretary; Lise Rice, Treasurer.
+The Co-op officers are: Greg Meredith, President; Evan Jensen, Secretary; Lisa Rice, Treasurer.
 
 There are three steering committees where Members collaborate to shape and organize the Cooperative: the Executive Committee, the Governance Committee, and the Compensation Committee. All committees have open participation but some are limited to 11 working members plus a chair.
 
@@ -113,7 +114,7 @@ Yes. The first step is to [register as a Member](https://member.rchain.coop), th
 “In theoretical computer science, the π-calculus is a process calculus. The π-calculus allows channel names to be communicated along the channels themselves, and in this way it is able to describe concurrent computations whose network configuration may change during the computation.” (Ref.: [https://en.wikipedia.org/wiki/Pi-calculus](https://en.wikipedia.org/wiki/Pi-calculus)). To better understand how it is being applied in the RChain development, check out the paper [Mobile process calculi for programming the blockchain](http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/).
 
 **What skills do I need to participate?**  \
-At this point the entire development focus is on the core platform. If you’re a seasoned developer willing to learn a new programming language (Rholang), have experience with functional programming, appreciate formal specifications, or have expertise in comms then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please [join as a Member](https://member.rchain.coop) and put yourself in the Talent Pool.
+At this point the entire development focus is on the core platform. The VM, storage, and networking layers are all written in Scala. There will eventually be code for Casper, the REV wallet, and a few other things in Rholang. If you’re a seasoned developer with Scala skills then please get in touch. Down the road more and varied skills will be needed. Programmers versed in other languages, web developers, designers, Javascript experts, system administrators, beta testers, and quality assurance people will be in demand. If you'd like to participate please [join as a Member](https://member.rchain.coop) and put yourself in the Talent Pool.
 
 **How can I learn Rholang?**  \
 An understanding of Pi Calculus will help. Join the Discord #rholang channel and ask questions.


### PR DESCRIPTION
The FAQ has been radically renovated resulting from the momentous Members Meeting. It needs a good read and editorial round. Ref #60. 

Notes
- Membership questions have all been moved to the Members section.
- Roadmap: this item needs some more beef.
- The comm channels do not include the new Telegram groups. They're still 'in beta' while we get new admins up to speed.
- All the subheadings (FAQ questions) will show as changed. It turns out that in Markdown backslashes don't render, so they're being used to make the stupid two-spaces markup for breaks visible.  \
