### PR TITLE
update faq_can 20180118

### DIFF
--- a/faq_cn.md
+++ b/faq_cn.md
@@ -1,0 +1,147 @@
+# RChain常见问题解答
+
+RChain中文网站 [http://rchain.site](http://rchain.site)
+
+### 章节
+
+[一般类问题](#general)  \
+[合作组织](#cooperative)  \
+[代币](#tokens)  \
+[会员](#members)  \
+[开发者](#developers)
+
+## 1、一般类问题
+
+**RChain是什么?**
+
+Rchain是一个全新的区块链平台，它来源于一种基于形式化验证的、去中心化的、并行计算模型。Rchain合作组织利用该模型来开发一个可并发的、可组合的、可无限伸缩的区块链。
+
+**白皮书在哪里?**
+
+白皮书链接如下：
+
+[https://docs.google.com/gview?url=https://github.com/rchain/reference/raw/master/docs/RChainWhitepaper.pdf](https://docs.google.com/gview?url=https://github.com/rchain/reference/raw/master/docs/RChainWhitepaper.pdf)
+
+RChain架构文档链接如下：
+
+[http://rchain-architecture.readthedocs.io/](http://rchain-architecture.readthedocs.io/)
+
+**哪里可以看到路线图？**
+
+我们正在研究发布一份全新的路线图，来源于十二月的一次研究人员代码精修活动。在本页面的顶部， [https://rchain.atlassian.net/wiki/spaces/CORE/overview](https://rchain.atlassian.net/wiki/spaces/CORE/overview)给出了一份50000步的总结。一份略显过时的平台快照可在以下页面中找到 [https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing](https://docs.google.com/spreadsheets/d/1_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing)
+
+**RChain是怎么来的?**
+
+RChain是创始人格雷格·梅雷迪思(Greg Meredith)一系列创新的集大成者。RChain的核心是基于移动进程代数，这是一个有着30年历史的数学分支。有着众多不同区块链的技术和经验的Greg，在2016年7月与 Synereo合作时编写了RChain的架构文档。Synereo的目标是创建一个以区块链为基础的社交网络，而RChain则为其基础技术。由于某些原因，最终Synereo创始人决定拆分RChain出去，以使Synereo团队专注于用现有的区块链技术提供一个社交网络，而Greg则专注于实现RChain的愿景。为此，RChain组织( [合作组织](https://www.rchain.coop/)和 [控股公司](https://www.rchain.io/))在2016年12月- 2017年1月成立。
+
+## 2、关于RChain合作组织
+
+**RChain合作组织与RChain控股公司的区别是什么?**
+
+合作组织是开发开源RChain平台软件的组织。它是一个开放的，由社区驱动的组织，目前有多个沟通渠道，欢迎所有人参与。RChain控股公司是一家以盈利为目的的实体，其使命是通过孵化初创企业、组建合资企业、开发产品和提供专业服务，在RChain平台周围培育生态系统。
+
+**RChain实体具体是在哪里?**
+
+RChain合作组织和RChain控股都是互联网公司，并在世界各地都有参与者。实体坐落于美国华盛顿，创始人住在西雅图。
+
+**RChain治理模型是什么？**
+
+RChain合作组织是一个成员驱动的组织，目前被选举的董事会成员为9人。董事会席位年限有3年、2年、一年三种。董事会目前构成如下：
+
+3年：Greg Meredith, Vlad Zamfir, Ian Bloom  \
+2年：Kenny Rowe, Evan Jensen, Alexandr Bulkin  \
+1年：Navneet Suman, Hendrik Jan Hilbolling, David Currin
+
+合作组织的官方人员包括： Greg Meredith, President; Evan Jensen, Secretary; Lisa Rice, Treasurer.
+
+为了更好的治理和组织合作组织，目前有三个指导委员会，分别为：执行委员会、治理委员会和薪酬委员会。所有委员会都对公开参选开放，但某些委员会人数只限于11位工作人员加一位主席。
+
+**RChain合作组织有哪些沟通渠道？**
+
+- 合作组织中的成员、领导者和开发者共享一个 [公共服务器](https://discord.gg/fvY8qhx)。若需获取服务器中各项纪录通道的授权， [请通过如下链接成为会员](https://member.rchain.coop/)。#slack 频道旧有链接[Slack](https://ourchain.slack.com)正逐步淘汰.
+- [Github](https://github.com/rchain/): 被用来进行代码和工程的协调沟通。
+- [Twitter](https://twitter.com/rchain_coop/): 提供新闻和公告的发布和更新。
+- 在Telegram上有[RChain交流群](https://t.me/rchain_coop) 和官方[公告频道](https://t.me/rchain_official).
+- 中国QQ群 ID: 中国朋友欢迎加入RChain粉丝群，QQ群号: 530718666
+- [Medium](https://medium.com/rchain-cooperative): 记载了更久远的博客公告。
+- [Youtube](https://www.youtube.com/channel/UCSS3jCffMiz574_q64Ukj_w): 中包含更新、直播和各项会议的记录。
+- Reddit: https://www.reddit.com/r/RChain/
+- Bitcointalk: https://bitcointalk.org/index.php?topic=2494040
+- [Facebook](https://www.facebook.com/rchaincooperative/): 和 [LinkedIn](https://www.linkedin.com/company/24997313/): 欢迎加入！
+- RChain会发出每周新闻. [网站订阅](https://www.rchain.coop/#joinus) 即可获取这些新闻.
+- 电话会议:Zoom.us 主要被用于电话会议，比如周三的每周报告。
+- 要查看过去的视频摘要和周报可以访问这个 [索引目录](https://github.com/rchain/Members/wiki/Weekly-Debrief-Index)。
+
+## 3、关于代币
+
+**RHOC是什么？**
+
+RHOC是以太坊ERC 20代币，于2017年早些时候由RChain合作组织发行，作为将来RChain的兑换凭证。目前有 861,185,194 RHOC存在，以后不会再发行更多的币. REV是未来RChain的基础货币，在RChain正式网络上线后，RHOC将1:1兑换REV。
+
+**是否有空投代币？**  \
+没有，与推特上流传的虚假空投文件不同, 目前没有任何计划空投.
+
+**RHOC,REV和其他原生代币的未来供应计划是什么？**
+
+这是一份已经过期的文件 [财务摘要, 分配方案, 和其他信息](https://docs.google.com/document/d/1lCVeO63E-WVosOnBIA2hH416Hs-Z0e1Av9eJWq-L20o/edit?usp=sharing). 这个是 [目前的分配方案](https://github.com/rchain/reference/blob/master/finance/rhoc.md).
+
+2017年11月的第一次成员会议决议提出&quot;合作组织不可将超过200,000,000的代币进入流通（包括任何人持有的代币，除合作组织自身持有及下个财政年中焚毁的代币外）&quot;。该决议的全文见 [官方博客报告](https://medium.com/rchain-cooperative/annual-meeting-summary-3827a82a2e33)
+
+**如何在 myetherwallet.com中显示代币 and Metamask**
+
+点击 "Add Custom Token", 填写如下信息:  \
+Contract Address: 0x168296bb09e24a88805cb9c33356536b980d3fc5  \
+Token Symbol: RHOC  \
+Decimals: 8
+
+**哪里可以交易RHOC？**
+
+RChain还没有认可RHOC交易，由于私下出售的仍未成熟，但其可能在未来获得认可。
+
+**还有没有可能用AMP换RHOC？**
+
+已经不能直接兑换了，最后期限是2017年4月。目前AMP和RHOC都已经上了交易所，如需兑换，请自行买卖。
+
+## 4、关于成员
+
+**我将如何加入RChain？**
+
+希望加入RChian公开讨论的可以参见前述的公开渠道。希望在扮演更加活跃角色的参与者，可以在代码和组织发展项目中合作，创建合作组织架构，并且参与治理构建，参见 [本链接](https://github.com/rchain/Members/blob/master/CONTRIBUTING.md)以获取全部消息。
+
+**什么是成员计划？**
+
+感兴趣的个人可以成为合作组织的一员。福利包括：获得公共记录服务器中的全部渠道权限，选举董事会成员，参加管理决策会议，参与提议和参与工程合作，并且就项目决策和预算控制作出决定。额外的福利将随着发展逐项确定。加入会员要求KYC和20美元的一次性会员费。
+
+**我住在美国境外。我可以加入吗?**
+
+是的，除非你居住在美国实施制裁的地区。在注册过程中，将对这一信息进行确认。
+
+**有奖励计划吗？**
+
+是。赏金的获得来源于基于同行评审的任务。任务不尽相同，但是核心开发，社区建设，市场营销，业务发展和渠道运营通常都将产生可用的奖励。 Github用于 [问题跟踪和项目管理](https://github.com/rchain/Members/)。
+
+**在参与项目时，可以获得RHOC么？**
+
+是的。请参见 [贡献文档](https://github.com/rchain/Members/blob/master/CONTRIBUTING.md)，并选择您感兴趣的项目。
+
+## 5、关于开发人员
+
+**什么是PI演算?**
+
+在理论计算科学领域，π演算是一种过程演算。π演算允许命名空间在通道中进行传递，这样，使得在计算中导致网络配置变化的并行计算通过这种演算成为可能。 (Ref.:  [https://en.wikipedia.org/wiki/Pi-calculus](https://en.wikipedia.org/wiki/Pi-calculus)). 需要更好的理解π演算在RChain发展中的应用方法，可参加这篇文献  [Mobile process calculi for programming the blockchain](http://mobile-process-calculi-for-programming-the-new-blockchain.readthedocs.io/en/latest/).
+
+**参与RChain开发需要具备哪些技能?**
+
+在目前阶段，团队的开发重心集中在核心平台上。VM、存储以及网络层级架构采用Scala进行编写。在开发的下几个阶段，将进行Casper、REV钱包以及Rholang中的一些内容。如您是一名具有丰富经验的Scala开发者，请与我们联系。在开发的过程中，我们将需要具有更多不同技能的开发者， Web开发人员，设计师，Javascript专家，系统管理员，beta测试员以及质量保证人员均在我们的人员需求范围中。如您有意愿加入我们，请点击  [join as a Member](https://member.rchain.coop/) 加入我们的人才池。
+
+**如何学习Rholang?**
+
+对π演算的熟练掌握将帮助您的学习过程. 加入  [RChain&#39;s Discord](https://discord.gg/fvY8qhx)了解更多
+
+**RChain 组件具有哪些许可?**
+
+RChain组件均为开源且具有免费软件许可. Apache v2在我们的选择范围中。 Rholang 是唯一加入 MIT license的组件。
+
+## 6、如果有建议怎么办？
+
+仍有问题未被解答？您可通过在公共频道中发表带有#faq的内容来提出其他问题和建议。


### PR DESCRIPTION
1. Repair link https://docs.google.com/spreadsheets/d/1\_cPts5BdoZVmbikDGUhkgkdQvkeXbP6aKNI31O0BV3E/edit?usp=sharing
2. in faq_cn.md the reference of Synereo are same to the faq.md
3. remove reference to ourchain.slack.com
4. I did not find "“RChain Exchange Group” 
5. The full text of the resolution is available at [https://medium.com/rchain-cooperative/annual-meeting-summary-3827a82a2e33](https://medium.com/rchain-cooperative/annual-meeting-summary-3827a82a2e33]  in faq_cn.md is the same to faq.md
6. fixed other bugs