### PR TITLE
ICA is authority on Co-ops

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Here's a collection of useful links at an easy to remember uri.
 
 ## Co-op
 
-* [About Cooperatives](http://www.prout.org/pna/cooperatives.html)
+* [ICA Guidance Notes on the Co-operative Principles](https://ica.coop/en/media/library/the-guidance-notes-on-the-co-operative-principles)
 
 * [Articles of Incorporation, Bylaws, and board minutes](https://github.com/rchain/board)
 


### PR DESCRIPTION
The ICA (International Co-operative Alliance) is the global steward of the Statement on the Co-operative Identity.
Removing - Prabhat Ranjan Sarkar refers to Cooperatives from the perspective of his (PROUT) Progressive Utilisation Theory philosophy.